### PR TITLE
HTTPS SSL

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -4,7 +4,7 @@ var xhr = require('xhr')
 module.exports = resolve
 
 function resolve(id, goal, callback) {
-  var uri = 'http://api.soundcloud.com/resolve.json?' + qs.stringify({
+  var uri = 'https://api.soundcloud.com/resolve.json?' + qs.stringify({
       url: goal
     , client_id: id
   })


### PR DESCRIPTION
The Waveform wont load on https Websites. 

```
Mixed Content: The page at 'https://www.xxxx.com' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://api.soundcloud.com/resolve.json?url=http%3A%2F%2Fsoundcloud.com%2Fxxx%2Fso-klingt-tirana&client_id=xxx'. This request has been blocked; the content must be served over HTTPS.
```
